### PR TITLE
Fix job retry

### DIFF
--- a/adit_radis_shared/common/management/commands/retry_stalled_jobs.py
+++ b/adit_radis_shared/common/management/commands/retry_stalled_jobs.py
@@ -1,44 +1,114 @@
 import asyncio
-import datetime
+import logging
 
+from asgiref.sync import sync_to_async
+from django.apps import apps
 from django.conf import settings
 from django.core.management.base import BaseCommand
+from django.db import transaction
 from procrastinate.contrib.django import app
+
+logger = logging.getLogger(__name__)
+
+
+## some helper functions
+def get_task_models():
+    task_models = []
+    for model in apps.get_models():
+        if hasattr(model, "Status") and hasattr(model, "queued_job_id"):
+            if hasattr(model.Status, "PENDING") and hasattr(model.Status, "IN_PROGRESS"):  # type: ignore
+                task_models.append(model)
+    return task_models
+
+
+def reset_task_state(task) -> None:
+    pending_status = getattr(task.Status, "PENDING", "PENDING")
+    task.status = pending_status
+    task.attempts = (task.attempts or 0) + 1
+    task.message = "Recovered from stalled state"
+    if hasattr(task, "start"):
+        task.start = None
+        task.end = None
+    elif hasattr(task, "started_at"):
+        task.started_at = None
+        task.ended_at = None
+    task.save()
+
+
+def update_job_status(task) -> None:
+    job = getattr(task, "job", None)
+    if job:
+        if hasattr(job, "update_job_state"):  # RADIS
+            job.update_job_state()
+        else:  # ADIT
+            pending_job_status = getattr(job.Status, "PENDING", "PENDING")
+            in_progress_status = getattr(job.Status, "IN_PROGRESS", "PENDING")
+            if (
+                job.status == in_progress_status
+                and not job.tasks.filter(status=in_progress_status).exists()
+            ):
+                job.status = pending_job_status
+                job.save()
 
 
 class Command(BaseCommand):
     help = "Retry stalled jobs in the procrastinate queue."
 
-    async def handle_retry_stalled_jobs(self):
+    async def handle_retry_stalled_jobs(self) -> tuple[int, int]:
         stalled_jobs = await app.job_manager.get_stalled_jobs()
 
-        priority: int = settings.STALLED_JOBS_RETRY_PRIORITY
+        if not stalled_jobs:
+            return 0, 0
 
-        stalled_jobs_num = 0
-        for job in stalled_jobs:
-            self.stdout.write(f"Retrying stalled job {job.id}...")
-            self.stdout.write(f"Job has status {job.status}. ")
-            await app.job_manager.retry_job(
-                job, priority=priority, retry_at=datetime.datetime(1990, 5, 17)
+        job_ids = {job.id: job for job in stalled_jobs}
+        tasks_recovered = 0
+        failed_tasks = 0
+
+        # Get all task models by checking for required attributes
+        task_models = get_task_models()
+
+        for task_model in task_models:
+            tasks = await sync_to_async(list)(
+                task_model.objects.filter(queued_job_id__in=job_ids.keys()).select_related("job")
             )
-            self.stdout.write(f"Job was retried and now has status {job.status}. ")
-            import time
 
-            time.sleep(70)
-            self.stdout.write(f"After one heartbeat time the status is not {job.status}. ")
-            stalled_jobs_num += 1
+            for task in tasks:
+                stalled_job = job_ids.get(getattr(task, "queued_job_id", None))
+                if not stalled_job:
+                    continue
 
-        return stalled_jobs_num
+                try:
+                    # Reset task state in transaction
+                    await sync_to_async(self._reset_task_state)(task)
 
-    def handle(self, *args, **options):
-        self.stdout.write("TEST... ", ending="")
-        self.stdout.write("Retrying stalled jobs... ", ending="")
-        self.stdout.flush()
+                    # Retry the job after state is committed (already in async context)
+                    retry_priority = getattr(settings, "STALLED_JOBS_RETRY_PRIORITY", 0)
+                    await app.job_manager.retry_job(stalled_job, priority=retry_priority)
+                    logger.info(f"Retried stalled job {stalled_job.id}")
 
-        stalled_jobs_num = asyncio.run(self.handle_retry_stalled_jobs())
-        if stalled_jobs_num == 0:
-            self.stdout.write("No stalled jobs found")
-        elif stalled_jobs_num == 1:
-            self.stdout.write("Found 1 stalled job")
+                    tasks_recovered += 1
+                except Exception as e:
+                    logger.error(f"Failed to recover task {task.id} (job {stalled_job.id}): {e}")
+                    failed_tasks += 1
+
+        # Check if any procrastinate jobs are still stalled without corresponding tasks
+        orphaned = len(job_ids) - tasks_recovered - failed_tasks
+
+        return tasks_recovered, orphaned
+
+    @transaction.atomic
+    def _reset_task_state(self, task) -> None:
+        reset_task_state(task)
+        update_job_status(task)
+
+    def handle(self, *args, **options) -> None:
+        self.stdout.write("Checking for stalled jobs...")
+        tasks_recovered, orphaned = asyncio.run(self.handle_retry_stalled_jobs())
+
+        if tasks_recovered == 0 and orphaned == 0:
+            self.stdout.write(self.style.SUCCESS("No stalled jobs found"))
         else:
-            self.stdout.write(f"Found {stalled_jobs_num} stalled jobs")
+            msg = f"Recovered {tasks_recovered} tasks"
+            if orphaned:
+                msg += f", found {orphaned} orphaned jobs"
+            self.stdout.write(msg)


### PR DESCRIPTION
The new fix-job-retry logic improves the previous one by:
- finding stuck procrastinate jobs
- (new) finding the appropriate Dicom/AnalysisTask for every procrastinate task and resetting its state
- (new) resetting the job state that the task belonged to, if needed;
- retrying the procrastinating job (now the task and job states will adapt their status accordingly).

In the event of server failure (or container restart), all tasks in progress will now be correctly retried.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved stalled job recovery with more robust state management and enhanced error handling.
  * Added identification and reporting of orphaned jobs during recovery operations.

* **Improvements**
  * Enhanced logging for successful and failed recovery attempts.
  * Provides consolidated results summary showing number of recovered tasks and orphaned jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->