### PR TITLE
Make Postgres wait timeout configurable

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -34,7 +34,7 @@ services:
     command: >
       bash -c "
         cd example_project;
-        wait-for-it -s postgres.local:5432 -t 60 && 
+        wait-for-it -s postgres.local:5432 -t ${WAIT_POSTGRES_TIMEOUT:-180} &&
         ./manage.py migrate &&
         ./manage.py create_superuser &&
         ./manage.py create_example_users &&
@@ -50,7 +50,7 @@ services:
     command: >
       bash -c "
         cd example_project;
-        wait-for-it -s postgres.local:5432 -t 60 &&
+        wait-for-it -s postgres.local:5432 -t ${WAIT_POSTGRES_TIMEOUT:-180} &&
         ./manage.py bg_worker -l debug --autoreload
       "
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -26,7 +26,7 @@ services:
     command: >
       bash -c "
         cd example_project;
-        wait-for-it -s postgres.local:5432 -t 60 && 
+        wait-for-it -s postgres.local:5432 -t ${WAIT_POSTGRES_TIMEOUT:-180} &&
         ./manage.py migrate &&
         ./manage.py collectstatic --no-input &&
         ./manage.py create_superuser &&
@@ -61,7 +61,7 @@ services:
     command: >
       bash -c "
         cd example_project;
-        wait-for-it -s postgres.local:5432 -t 60 &&
+        wait-for-it -s postgres.local:5432 -t ${WAIT_POSTGRES_TIMEOUT:-180} &&
         ./manage.py bg_worker
       "
 


### PR DESCRIPTION
## Summary

- Replace hard-coded `wait-for-it` timeouts with configurable `WAIT_POSTGRES_TIMEOUT` environment variable across all docker-compose files
- Default is 180 seconds, overridable via `.env`

See also openradx/radis#212

## Test plan

- [ ] Verify `docker compose config` correctly interpolates the default (180s) when `WAIT_POSTGRES_TIMEOUT` is unset
- [ ] Verify setting `WAIT_POSTGRES_TIMEOUT=300` in `.env` overrides all `wait-for-it` calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker service startup configuration with configurable database readiness timeout, increasing the default wait duration for improved initialization reliability in development and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->