### PR TITLE
Inject STACK_NAME into container env from CLI commands

### DIFF
--- a/adit_radis_shared/cli/commands.py
+++ b/adit_radis_shared/cli/commands.py
@@ -96,6 +96,7 @@ def compose_build(
         env={
             "COMPOSE_BAKE": "true",
             "PROJECT_VERSION": helper.get_local_project_version(),
+            "STACK_NAME": helper.get_stack_name(),
         },
     )
 
@@ -154,6 +155,7 @@ def compose_up(
         env={
             "COMPOSE_BAKE": "true",
             "PROJECT_VERSION": helper.get_local_project_version(),
+            "STACK_NAME": helper.get_stack_name(),
         },
     )
 
@@ -197,6 +199,7 @@ def stack_deploy():
     env = helper.load_config_from_env_file()
 
     env["PROJECT_VERSION"] = helper.get_local_project_version()
+    env["STACK_NAME"] = helper.get_stack_name()
 
     cmd = "docker stack deploy --detach "
     cmd += f" -c {helper.get_compose_base_file()}"


### PR DESCRIPTION
## Summary
- Pass `STACK_NAME` via `helper.get_stack_name()` to the env dict in `compose_build`, `compose_up`, and `stack_deploy`
- This allows containers to derive a unique session cookie name per deployment, preventing cookie conflicts between dev/staging/prod on the same host

## Test plan
- [ ] Verify `uv run cli compose-up` passes `STACK_NAME` to containers
- [ ] Verify `uv run cli lint` passes in dependent projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Stack name environment variable is now correctly passed to build and deployment commands, ensuring proper stack identification and management throughout deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->