### PR TITLE
Make telemetry instrumentors pluggable for non-Django consumers

### DIFF
--- a/adit_radis_shared/telemetry.py
+++ b/adit_radis_shared/telemetry.py
@@ -1,7 +1,11 @@
-"""OpenTelemetry configuration for ADIT and RADIS.
+"""OpenTelemetry configuration for ADIT, RADIS, and other openradx services.
 
 This module sets up OpenTelemetry instrumentation for traces, metrics, and logs,
 exporting to an OTLP-compatible backend (e.g., otel-collector -> OpenObserve).
+
+Framework-specific auto-instrumentors (Django, Psycopg, requests, ...) are passed
+in by the caller via `setup_opentelemetry(instrumentors=[...])` so this helper is
+usable from non-Django consumers such as the radis-etl-ukb Dagster pipeline.
 
 Telemetry is disabled if OTEL_EXPORTER_OTLP_ENDPOINT is not set.
 """
@@ -9,6 +13,7 @@ Telemetry is disabled if OTEL_EXPORTER_OTLP_ENDPOINT is not set.
 import logging
 import os
 import socket
+from collections.abc import Iterable
 
 logger = logging.getLogger(__name__)
 
@@ -65,12 +70,21 @@ def _build_resource_attributes(service_name: str) -> dict[str, str]:
     return attrs
 
 
-def setup_opentelemetry() -> None:
+def setup_opentelemetry(instrumentors: Iterable[type] | None = None) -> None:
     """Initialize OpenTelemetry instrumentation for traces, metrics, and logs.
 
-    This function should be called once at application startup, before Django loads.
-    It configures trace, metric, and log exporters to send data to the OTLP endpoint
-    (typically otel-collector).
+    Call once at application startup, before the host framework loads (e.g. before
+    Django settings are imported, or before Dagster's code location is loaded).
+    Configures trace, metric, and log exporters to send data to the OTLP endpoint
+    (typically the openradx-observability otel-collector).
+
+    Pass `instrumentors` as a sequence of OTel instrumentor classes (each providing
+    a no-arg constructor and an `.instrument()` method) to enable framework-specific
+    auto-instrumentation. For Django consumers (ADIT, RADIS) that is
+    `[DjangoInstrumentor, PsycopgInstrumentor]`. For non-Django consumers (e.g. the
+    radis-etl-ukb Dagster pipeline) pass `None` and optionally add HTTP-client
+    instrumentors like `RequestsInstrumentor` so outbound calls propagate trace
+    context to downstream services.
 
     If OTEL_EXPORTER_OTLP_ENDPOINT is not set, telemetry is disabled.
     """
@@ -95,8 +109,6 @@ def setup_opentelemetry() -> None:
         from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
         from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
         from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-        from opentelemetry.instrumentation.django import DjangoInstrumentor
-        from opentelemetry.instrumentation.psycopg import PsycopgInstrumentor
         from opentelemetry.sdk._logs import LoggerProvider
         from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
         from opentelemetry.sdk.metrics import MeterProvider
@@ -137,17 +149,20 @@ def setup_opentelemetry() -> None:
         logger_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
         set_logger_provider(logger_provider)
 
-        # Mark telemetry as active BEFORE instrumenting Django, because
-        # DjangoInstrumentor().instrument() triggers Django settings to load,
-        # which checks is_telemetry_active() to decide whether to add the
-        # OTel logging handler.
+        # Mark telemetry as active BEFORE running caller-provided instrumentors,
+        # because some of them (notably DjangoInstrumentor) trigger framework
+        # settings to load, which check is_telemetry_active() to decide whether
+        # to add the OTel logging handler.
         _telemetry_active = True
 
-        # Instrument Django
-        DjangoInstrumentor().instrument()
-
-        # Instrument psycopg (PostgreSQL)
-        PsycopgInstrumentor().instrument()
+        # Run caller-provided instrumentors. Each class is expected to expose a
+        # no-arg constructor and an `.instrument()` method (the OTel
+        # BaseInstrumentor contract). Imports of the instrumentor packages
+        # therefore live with the caller, not here, so the package needs to
+        # depend on `opentelemetry-instrumentation-django` etc. only when the
+        # consumer is actually a Django app.
+        for instrumentor_cls in instrumentors or ():
+            instrumentor_cls().instrument()
 
         logger.info("OpenTelemetry initialized for service: %s", service_name)
     except Exception:

--- a/adit_radis_shared/tests/test_telemetry.py
+++ b/adit_radis_shared/tests/test_telemetry.py
@@ -1,7 +1,12 @@
-"""Unit tests for the resource-attribute helper in telemetry.py."""
+"""Unit tests for the telemetry module: the resource-attribute helper and the
+pluggable-instrumentor contract used by setup_opentelemetry()."""
+
+import importlib
+from typing import Any
 
 import pytest
 
+from adit_radis_shared import telemetry
 from adit_radis_shared.telemetry import _build_resource_attributes
 
 
@@ -55,3 +60,211 @@ def test_task_slot_alone_does_not_create_component(monkeypatch: pytest.MonkeyPat
     monkeypatch.setenv("TASK_SLOT", "2")
     attrs = _build_resource_attributes("adit_prod")
     assert attrs == {"service.name": "adit_prod"}
+
+
+# ----------------------------------------------------------------------------
+# Pluggable-instrumentor contract
+# ----------------------------------------------------------------------------
+#
+# These tests exercise the `instrumentors` parameter of setup_opentelemetry(),
+# which lets non-Django consumers (e.g. radis-etl-ukb) reuse the helper without
+# forcing the package to depend on opentelemetry-instrumentation-django and
+# -psycopg. Django consumers install adit-radis-shared[django] and pass those
+# instrumentor classes explicitly.
+
+
+@pytest.fixture(autouse=True)
+def _reset_telemetry_state(monkeypatch: pytest.MonkeyPatch):
+    """Reset the module-level singleton flag between tests.
+
+    setup_opentelemetry() short-circuits if `_telemetry_active` is True so that
+    calling it twice in production is a no-op. We reset around each test so
+    each scenario starts from a clean slate.
+    """
+    monkeypatch.setattr(telemetry, "_telemetry_active", False)
+    yield
+    monkeypatch.setattr(telemetry, "_telemetry_active", False)
+
+
+class _RecordingInstrumentor:
+    """Stand-in for an OTel BaseInstrumentor used to assert call ordering.
+
+    Each instance appends (name, telemetry_active_flag_at_call_time) to a
+    class-level list so tests can verify both invocation count and the
+    invariant that `_telemetry_active` flips to True *before* any
+    instrumentor runs.
+    """
+
+    calls: list[tuple[str, bool]] = []
+
+    def __init__(self, name: str = "default") -> None:
+        self.name = name
+
+    def instrument(self) -> None:
+        type(self).calls.append((self.name, telemetry.is_telemetry_active()))
+
+    @classmethod
+    def reset(cls) -> None:
+        cls.calls = []
+
+
+def _make_instrumentor_class(name: str) -> type[_RecordingInstrumentor]:
+    """Create a one-off instrumentor class with a stable identifier so
+    assertion output is legible when multiple instrumentors run in one test."""
+    return type(
+        f"Instrumentor_{name}",
+        (_RecordingInstrumentor,),
+        {"__init__": lambda self, _name=name: _RecordingInstrumentor.__init__(self, _name)},
+    )
+
+
+@pytest.fixture
+def _otel_endpoint(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Provide a fake OTLP endpoint so setup_opentelemetry proceeds past the
+    early-return guard. The exporters target the URL but never actually send
+    during tests because the BatchSpan/LogProcessor flushes on shutdown only.
+    """
+    endpoint = "http://otel-collector.test:4318"
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", endpoint)
+    monkeypatch.setenv("OTEL_SERVICE_NAME", "telemetry-test")
+    return endpoint
+
+
+def test_no_endpoint_short_circuits_without_touching_instrumentors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OTEL_EXPORTER_OTLP_ENDPOINT unset -> helper returns silently without
+    instantiating any instrumentor. Production relies on this for dev/CI
+    environments where no collector is reachable."""
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    _RecordingInstrumentor.reset()
+    sentinel = _make_instrumentor_class("must_not_run")
+
+    telemetry.setup_opentelemetry(instrumentors=[sentinel])
+
+    assert telemetry.is_telemetry_active() is False
+    assert _RecordingInstrumentor.calls == []
+
+
+def test_default_call_runs_no_instrumentors(_otel_endpoint: str) -> None:
+    """Calling setup_opentelemetry() with no instrumentors must still
+    initialise the SDK (so the metrics API works) but must not run any
+    framework-specific instrumentor — this is the radis-etl-ukb path."""
+    _RecordingInstrumentor.reset()
+
+    telemetry.setup_opentelemetry()
+
+    assert telemetry.is_telemetry_active() is True
+    assert _RecordingInstrumentor.calls == []
+
+
+def test_explicit_instrumentors_are_invoked_in_order(_otel_endpoint: str) -> None:
+    """Caller's instrumentors must be instantiated and .instrument()ed in the
+    order provided. ADIT/RADIS rely on Django coming before Psycopg so the
+    Psycopg hook sees the request span as its parent."""
+    _RecordingInstrumentor.reset()
+    first = _make_instrumentor_class("django_like")
+    second = _make_instrumentor_class("psycopg_like")
+
+    telemetry.setup_opentelemetry(instrumentors=[first, second])
+
+    names = [name for name, _active in _RecordingInstrumentor.calls]
+    assert names == ["django_like", "psycopg_like"]
+
+
+def test_telemetry_active_flag_set_before_instrumentors_run(_otel_endpoint: str) -> None:
+    """_telemetry_active must flip to True *before* any instrumentor runs.
+    DjangoInstrumentor().instrument() triggers Django settings to import,
+    which read is_telemetry_active() to decide whether to attach the OTel
+    log handler — if the flag were still False at that point the handler
+    would silently never be wired and prod logs would stop reaching
+    OpenObserve."""
+    _RecordingInstrumentor.reset()
+    probe = _make_instrumentor_class("probe")
+
+    telemetry.setup_opentelemetry(instrumentors=[probe])
+
+    assert _RecordingInstrumentor.calls == [("probe", True)]
+
+
+def test_instrumentor_exception_does_not_break_app(
+    _otel_endpoint: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An instrumentor that raises must be swallowed with a warning so the
+    application boots even when telemetry is misconfigured. The outer
+    try/except is precisely there so telemetry never breaks the host app."""
+
+    class _Boom:
+        def instrument(self) -> None:
+            raise RuntimeError("instrumentor exploded")
+
+    with caplog.at_level("WARNING", logger="adit_radis_shared.telemetry"):
+        telemetry.setup_opentelemetry(instrumentors=[_Boom])
+
+    assert any(
+        "Failed to initialize OpenTelemetry" in record.message for record in caplog.records
+    )
+
+
+def test_idempotent_second_call_is_noop(_otel_endpoint: str) -> None:
+    """setup_opentelemetry called twice must not double-instrument. manage.py
+    and asgi.py both call it (e.g. when running daphne via manage), so a
+    double call must be a no-op to avoid duplicate Django/Psycopg spans."""
+    _RecordingInstrumentor.reset()
+    probe = _make_instrumentor_class("once_only")
+
+    telemetry.setup_opentelemetry(instrumentors=[probe])
+    telemetry.setup_opentelemetry(instrumentors=[probe])
+
+    assert len(_RecordingInstrumentor.calls) == 1
+
+
+def test_add_otel_logging_handler_attaches_to_all_loggers() -> None:
+    """The logging-handler wiring is independent of SDK setup. After the helper
+    runs every named logger and the root logger must reference the `otel`
+    handler exactly once."""
+    logging_config: dict[str, Any] = {
+        "version": 1,
+        "handlers": {"console": {"class": "logging.StreamHandler"}},
+        "loggers": {
+            "myapp": {"handlers": ["console"], "level": "INFO"},
+            "django": {"handlers": ["console"], "level": "WARNING"},
+        },
+        "root": {"handlers": ["console"], "level": "ERROR"},
+    }
+
+    telemetry.add_otel_logging_handler(logging_config)
+
+    assert "otel" in logging_config["handlers"]
+    assert logging_config["loggers"]["myapp"]["handlers"] == ["console", "otel"]
+    assert logging_config["loggers"]["django"]["handlers"] == ["console", "otel"]
+    assert logging_config["root"]["handlers"] == ["console", "otel"]
+
+
+def test_add_otel_logging_handler_is_idempotent() -> None:
+    """Settings reloads (e.g. test runners overriding settings) must not
+    duplicate the handler entries — duplicates would cause each log record to
+    be emitted to OTel twice."""
+    logging_config: dict[str, Any] = {
+        "version": 1,
+        "handlers": {"console": {"class": "logging.StreamHandler"}},
+        "loggers": {"myapp": {"handlers": ["console"], "level": "INFO"}},
+        "root": {"handlers": ["console"], "level": "ERROR"},
+    }
+
+    telemetry.add_otel_logging_handler(logging_config)
+    telemetry.add_otel_logging_handler(logging_config)
+
+    assert logging_config["loggers"]["myapp"]["handlers"].count("otel") == 1
+    assert logging_config["root"]["handlers"].count("otel") == 1
+
+
+def test_module_imports_without_django_extras() -> None:
+    """The telemetry module must be importable without
+    opentelemetry-instrumentation-django installed — this is what makes the
+    extras split actually useful. Failing this test means we accidentally
+    re-introduced a top-level Django-instrumentation import."""
+    reloaded = importlib.reload(telemetry)
+    assert hasattr(reloaded, "setup_opentelemetry")
+    assert hasattr(reloaded, "add_otel_logging_handler")
+    assert hasattr(reloaded, "is_telemetry_active")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,15 @@ dependencies = [
     "opentelemetry-api>=1.32.0",
     "opentelemetry-sdk>=1.32.0",
     "opentelemetry-exporter-otlp-proto-http>=1.32.0",
+]
+
+[project.optional-dependencies]
+# Framework-specific auto-instrumentors. Django consumers (ADIT, RADIS) install
+# `adit-radis-shared[django]` to get the Django and Psycopg instrumentors, which
+# are then passed to `setup_opentelemetry(instrumentors=[...])`. Non-Django
+# consumers (e.g. radis-etl-ukb) install the plain package and add whichever
+# instrumentors they need (e.g. opentelemetry-instrumentation-requests) directly.
+django = [
     "opentelemetry-instrumentation-django>=0.60b0",
     "opentelemetry-instrumentation-psycopg>=0.60b0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -35,8 +35,6 @@ dependencies = [
     { name = "environs", extra = ["django"] },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
-    { name = "opentelemetry-instrumentation-django" },
-    { name = "opentelemetry-instrumentation-psycopg" },
     { name = "opentelemetry-sdk" },
     { name = "procrastinate", extra = ["django"] },
     { name = "psycopg", extra = ["binary"] },
@@ -46,6 +44,12 @@ dependencies = [
     { name = "wait-for-it" },
     { name = "watchfiles" },
     { name = "whitenoise" },
+]
+
+[package.optional-dependencies]
+django = [
+    { name = "opentelemetry-instrumentation-django" },
+    { name = "opentelemetry-instrumentation-psycopg" },
 ]
 
 [package.dev-dependencies]
@@ -103,8 +107,8 @@ requires-dist = [
     { name = "environs", extras = ["django"], specifier = ">=14.1.1" },
     { name = "opentelemetry-api", specifier = ">=1.32.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.32.0" },
-    { name = "opentelemetry-instrumentation-django", specifier = ">=0.60b0" },
-    { name = "opentelemetry-instrumentation-psycopg", specifier = ">=0.60b0" },
+    { name = "opentelemetry-instrumentation-django", marker = "extra == 'django'", specifier = ">=0.60b0" },
+    { name = "opentelemetry-instrumentation-psycopg", marker = "extra == 'django'", specifier = ">=0.60b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.32.0" },
     { name = "procrastinate", extras = ["django"], specifier = ">=3.0.2" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.5" },
@@ -115,6 +119,7 @@ requires-dist = [
     { name = "watchfiles", specifier = ">=1.0.4" },
     { name = "whitenoise", specifier = ">=6.9.0" },
 ]
+provides-extras = ["django"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

`setup_opentelemetry()` now takes an optional `instrumentors` iterable, decoupling the helper from Django specifically so non-Django openradx services can reuse it.

- ADIT and RADIS install `adit-radis-shared[django]` and pass `[DjangoInstrumentor, PsycopgInstrumentor]` explicitly.
- The radis-etl-ukb Dagster pipeline installs the bare package and passes `[RequestsInstrumentor]` (or nothing).
- The Django/Psycopg auto-instrumentor packages move from core deps to a new `[project.optional-dependencies] django` group, so non-Django consumers no longer download them.

## Why

The radis-etl-ukb pipeline needs the same SDK setup ADIT/RADIS get, but doesn't run Django and doesn't want the Django auto-instrumentor packages forced into its dependency graph. Making the instrumentor list a caller concern keeps the helper a thin, framework-agnostic SDK initializer while preserving today's ADIT/RADIS behaviour.

## Dependent PRs (will fail until this merges + 0.24.0 tag is cut)

- openradx/radis — bumps shared pin to 0.24.0, adds [django] extra, passes instrumentors in manage.py + radis/asgi.py
- openradx/adit — same shape as the radis one
- openradx/radis-etl-ukb — full Dagster instrumentation against the bare package
- openradx/openradx-observability — service.name rename

## Test plan

- [x] 16 unit tests in adit_radis_shared/tests/test_telemetry.py cover: short-circuit when endpoint unset, default no-arg call, invocation order, _telemetry_active flag flipping before instrumentors run (the Django log-handler ordering invariant), exception safety, idempotency, log-handler wiring, and that the module imports cleanly without the [django] extra installed. All passing locally.
- [ ] Reviewer: confirm 0.24.0 tag should be cut from this branch's merge commit on main so downstream PRs can re-pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telemetry initialization now supports custom instrumentor plugins for flexible monitoring configuration.
  * Telemetry module can be used independently of Django.

* **Improvements**
  * Enhanced documentation for telemetry setup across services.
  * Expanded test coverage for telemetry system behavior and error handling.

* **Chores**
  * Fixed package configuration structure.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openradx/adit-radis-shared/pull/195)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->