### PR TITLE
Require `from __future__ import annotations` (ruff I002)

### DIFF
--- a/adit_radis_shared/accounts/admin.py
+++ b/adit_radis_shared/accounts/admin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.contrib import admin
 from django.contrib.auth.admin import GroupAdmin, UserAdmin
 from django.contrib.auth.forms import UserChangeForm

--- a/adit_radis_shared/accounts/apps.py
+++ b/adit_radis_shared/accounts/apps.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.apps import AppConfig
 
 

--- a/adit_radis_shared/accounts/backends.py
+++ b/adit_radis_shared/accounts/backends.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.contrib.auth.backends import ModelBackend
 from django.contrib.auth.models import Permission
 from django.db.models import Model

--- a/adit_radis_shared/accounts/factories.py
+++ b/adit_radis_shared/accounts/factories.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import cast
 
 import factory

--- a/adit_radis_shared/accounts/forms.py
+++ b/adit_radis_shared/accounts/forms.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from crispy_forms.helper import FormHelper

--- a/adit_radis_shared/accounts/middlewares.py
+++ b/adit_radis_shared/accounts/middlewares.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import cast
 
 from django.http import HttpRequest

--- a/adit_radis_shared/accounts/models.py
+++ b/adit_radis_shared/accounts/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.contrib.auth.models import AbstractUser, Group
 from django.db import models
 

--- a/adit_radis_shared/accounts/tests/acceptance/conftest.py
+++ b/adit_radis_shared/accounts/tests/acceptance/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 # Workaround to make playwright work with Django

--- a/adit_radis_shared/accounts/tests/acceptance/test_login.py
+++ b/adit_radis_shared/accounts/tests/acceptance/test_login.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from playwright.sync_api import Page, expect
 from pytest_django.live_server_helper import LiveServer

--- a/adit_radis_shared/accounts/tests/test_migrations.py
+++ b/adit_radis_shared/accounts/tests/test_migrations.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from django_test_migrations.migrator import Migrator
 

--- a/adit_radis_shared/accounts/urls.py
+++ b/adit_radis_shared/accounts/urls.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.urls import include, path
 
 from . import views

--- a/adit_radis_shared/accounts/views.py
+++ b/adit_radis_shared/accounts/views.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.contrib.auth.mixins import AccessMixin, LoginRequiredMixin
 from django.core.exceptions import SuspiciousOperation, ValidationError
 from django.views import View

--- a/adit_radis_shared/cli/commands.py
+++ b/adit_radis_shared/cli/commands.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import shutil
 import sys

--- a/adit_radis_shared/cli/helper.py
+++ b/adit_radis_shared/cli/helper.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import binascii
 import ipaddress
 import os

--- a/adit_radis_shared/common/admin.py
+++ b/adit_radis_shared/common/admin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.contrib import admin
 
 from .models import ProjectSettings

--- a/adit_radis_shared/common/apps.py
+++ b/adit_radis_shared/common/apps.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.apps import AppConfig
 from django.conf import settings
 from django.db.models.signals import post_migrate

--- a/adit_radis_shared/common/exceptions.py
+++ b/adit_radis_shared/common/exceptions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from rest_framework.exceptions import APIException
 
 

--- a/adit_radis_shared/common/factories.py
+++ b/adit_radis_shared/common/factories.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import factory
 from faker import Faker
 

--- a/adit_radis_shared/common/forms.py
+++ b/adit_radis_shared/common/forms.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from crispy_forms.bootstrap import FieldWithButtons
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Div, Field, Hidden, Layout, Submit

--- a/adit_radis_shared/common/management/base/procrastinate_worker.py
+++ b/adit_radis_shared/common/management/base/procrastinate_worker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import shlex
 import subprocess

--- a/adit_radis_shared/common/management/base/server_command.py
+++ b/adit_radis_shared/common/management/base/server_command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import signal
 import subprocess

--- a/adit_radis_shared/common/management/commands/bg_worker.py
+++ b/adit_radis_shared/common/management/commands/bg_worker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.conf import settings
 
 from adit_radis_shared.common.management.base.procrastinate_worker import ProcrastinateServerCommand

--- a/adit_radis_shared/common/management/commands/create_example_groups.py
+++ b/adit_radis_shared/common/management/commands/create_example_groups.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from typing import Any
 

--- a/adit_radis_shared/common/management/commands/create_example_users.py
+++ b/adit_radis_shared/common/management/commands/create_example_users.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from django.core.management.base import BaseCommand, CommandParser

--- a/adit_radis_shared/common/management/commands/create_superuser.py
+++ b/adit_radis_shared/common/management/commands/create_superuser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from django.core.management.base import BaseCommand

--- a/adit_radis_shared/common/management/commands/example_async_server.py
+++ b/adit_radis_shared/common/management/commands/example_async_server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 
 from adit_radis_shared.common.management.base.server_command import AsyncServerCommand

--- a/adit_radis_shared/common/management/commands/example_server.py
+++ b/adit_radis_shared/common/management/commands/example_server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 
 from adit_radis_shared.common.management.base.server_command import ServerCommand

--- a/adit_radis_shared/common/management/commands/hard_reset_migrations.py
+++ b/adit_radis_shared/common/management/commands/hard_reset_migrations.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from django.conf import settings

--- a/adit_radis_shared/common/management/commands/ok_server.py
+++ b/adit_radis_shared/common/management/commands/ok_server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from argparse import ArgumentParser
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any

--- a/adit_radis_shared/common/management/commands/retry_stalled_jobs.py
+++ b/adit_radis_shared/common/management/commands/retry_stalled_jobs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 
 from django.conf import settings

--- a/adit_radis_shared/common/management/commands/send_test_mail.py
+++ b/adit_radis_shared/common/management/commands/send_test_mail.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.mail import send_mail

--- a/adit_radis_shared/common/middlewares.py
+++ b/adit_radis_shared/common/middlewares.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 from django.http import HttpResponse

--- a/adit_radis_shared/common/mixins.py
+++ b/adit_radis_shared/common/mixins.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Protocol
 
 from django.core.exceptions import SuspiciousOperation

--- a/adit_radis_shared/common/models.py
+++ b/adit_radis_shared/common/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.db import models
 
 
@@ -12,7 +14,7 @@ class ProjectSettings(models.Model):
         return f"{self.__class__.__name__} [{self.pk}]"
 
     @classmethod
-    def get(cls) -> "ProjectSettings":
+    def get(cls) -> ProjectSettings:
         project_settings = cls.objects.first()
         # We made sure during startup that there is always a ProjectSettings
         # (see common/apps.py)
@@ -27,7 +29,7 @@ class AppSettings(models.Model):
         abstract = True
 
     @classmethod
-    def get(cls) -> "AppSettings":
+    def get(cls) -> AppSettings:
         app_settings = cls.objects.first()
         # We made sure during startup that there is always a AppSettings
         # (see apps.py of the specific app)

--- a/adit_radis_shared/common/site.py
+++ b/adit_radis_shared/common/site.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, NamedTuple
 
 from django.conf import settings

--- a/adit_radis_shared/common/tasks.py
+++ b/adit_radis_shared/common/tasks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 from django.conf import settings

--- a/adit_radis_shared/common/templatetags/common_extras.py
+++ b/adit_radis_shared/common/templatetags/common_extras.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from datetime import date, datetime, time
 from typing import Any, Literal

--- a/adit_radis_shared/common/types.py
+++ b/adit_radis_shared/common/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Protocol, cast
 
 from crispy_forms.helper import FormHelper

--- a/adit_radis_shared/common/utils/async_utils.py
+++ b/adit_radis_shared/common/utils/async_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 from collections.abc import AsyncIterator
 

--- a/adit_radis_shared/common/utils/auth_utils.py
+++ b/adit_radis_shared/common/utils/auth_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TypeGuard
 
 from django.contrib.auth.models import AbstractBaseUser, AnonymousUser

--- a/adit_radis_shared/common/utils/debounce.py
+++ b/adit_radis_shared/common/utils/debounce.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import threading
 from functools import wraps
 

--- a/adit_radis_shared/common/utils/htmx_triggers.py
+++ b/adit_radis_shared/common/utils/htmx_triggers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Literal
 
 from django.http import HttpResponse

--- a/adit_radis_shared/common/utils/mail.py
+++ b/adit_radis_shared/common/utils/mail.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.conf import settings
 from django.core.mail import mail_admins, send_mail
 from django.utils.html import strip_tags

--- a/adit_radis_shared/common/utils/migration_utils.py
+++ b/adit_radis_shared/common/utils/migration_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from string import Template
 
 

--- a/adit_radis_shared/common/utils/testing_helpers.py
+++ b/adit_radis_shared/common/utils/testing_helpers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import time
 from collections.abc import Callable

--- a/adit_radis_shared/common/views.py
+++ b/adit_radis_shared/common/views.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from django.contrib import messages

--- a/adit_radis_shared/pytest_fixtures.py
+++ b/adit_radis_shared/pytest_fixtures.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from django.db import connection
 from django_test_migrations.migrator import Migrator

--- a/adit_radis_shared/telemetry.py
+++ b/adit_radis_shared/telemetry.py
@@ -10,6 +10,8 @@ usable from non-Django consumers such as the radis-etl-ukb Dagster pipeline.
 Telemetry is disabled if OTEL_EXPORTER_OTLP_ENDPOINT is not set.
 """
 
+from __future__ import annotations
+
 import logging
 import os
 import socket

--- a/adit_radis_shared/tests/test_telemetry.py
+++ b/adit_radis_shared/tests/test_telemetry.py
@@ -1,6 +1,8 @@
 """Unit tests for the telemetry module: the resource-attribute helper and the
 pluggable-instrumentor contract used by setup_opentelemetry()."""
 
+from __future__ import annotations
+
 import importlib
 from typing import Any
 

--- a/adit_radis_shared/token_authentication/admin.py
+++ b/adit_radis_shared/token_authentication/admin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.contrib import admin
 
 from .models import Token

--- a/adit_radis_shared/token_authentication/api_urls.py
+++ b/adit_radis_shared/token_authentication/api_urls.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.urls import path
 
 from .views import CheckAuthView

--- a/adit_radis_shared/token_authentication/apps.py
+++ b/adit_radis_shared/token_authentication/apps.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.apps import AppConfig
 
 

--- a/adit_radis_shared/token_authentication/auth.py
+++ b/adit_radis_shared/token_authentication/auth.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 from django.utils import timezone

--- a/adit_radis_shared/token_authentication/factories.py
+++ b/adit_radis_shared/token_authentication/factories.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import timedelta
 
 import factory

--- a/adit_radis_shared/token_authentication/forms.py
+++ b/adit_radis_shared/token_authentication/forms.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Div, Field, Layout, Submit
 from django import forms

--- a/adit_radis_shared/token_authentication/models.py
+++ b/adit_radis_shared/token_authentication/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import binascii
 from datetime import datetime
 from os import urandom

--- a/adit_radis_shared/token_authentication/tests/acceptance/conftest.py
+++ b/adit_radis_shared/token_authentication/tests/acceptance/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 # Workaround to make playwright work with Django

--- a/adit_radis_shared/token_authentication/tests/acceptance/test_token_authentication.py
+++ b/adit_radis_shared/token_authentication/tests/acceptance/test_token_authentication.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 import requests
 from playwright.sync_api import Page, expect

--- a/adit_radis_shared/token_authentication/urls.py
+++ b/adit_radis_shared/token_authentication/urls.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.urls import path
 
 from adit_radis_shared.common.views import HtmxTemplateView

--- a/adit_radis_shared/token_authentication/utils/crypto.py
+++ b/adit_radis_shared/token_authentication/utils/crypto.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.conf import settings
 from django.contrib.auth.hashers import check_password, make_password
 

--- a/adit_radis_shared/token_authentication/views.py
+++ b/adit_radis_shared/token_authentication/views.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from typing import Any
 

--- a/cli.py
+++ b/cli.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import os
 import shutil
 import sys

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import nest_asyncio
 
 pytest_plugins = ["adit_radis_shared.pytest_fixtures"]

--- a/example_project/example_project/asgi.py
+++ b/example_project/example_project/asgi.py
@@ -7,6 +7,8 @@ For more information on this file, see
 https://docs.djangoproject.com/en/5.0/howto/deployment/asgi/
 """
 
+from __future__ import annotations
+
 import os
 
 from django.core.asgi import get_asgi_application

--- a/example_project/example_project/example_app/apps.py
+++ b/example_project/example_project/example_app/apps.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.apps import AppConfig
 
 from adit_radis_shared.common.site import MainMenuItem, register_main_menu_item

--- a/example_project/example_project/example_app/factories.py
+++ b/example_project/example_project/example_app/factories.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import factory
 
 from adit_radis_shared.common.factories import BaseDjangoModelFactory

--- a/example_project/example_project/example_app/filters.py
+++ b/example_project/example_project/example_app/filters.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import django_filters
 from django.http import HttpRequest
 

--- a/example_project/example_project/example_app/forms.py
+++ b/example_project/example_project/example_app/forms.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django import forms
 
 

--- a/example_project/example_project/example_app/management/commands/create_example_jobs.py
+++ b/example_project/example_project/example_app/management/commands/create_example_jobs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from django.core.management.base import BaseCommand, CommandParser

--- a/example_project/example_project/example_app/models.py
+++ b/example_project/example_project/example_app/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.db import models
 
 

--- a/example_project/example_project/example_app/tables.py
+++ b/example_project/example_project/example_app/tables.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django_tables2 import tables
 
 from .models import ExampleJob

--- a/example_project/example_project/example_app/tasks.py
+++ b/example_project/example_project/example_app/tasks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import procrastinate
 from procrastinate.contrib.django import app
 

--- a/example_project/example_project/example_app/tests/test_tasks.py
+++ b/example_project/example_project/example_app/tests/test_tasks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time_machine
 from procrastinate.app import App
 from pytest import CaptureFixture

--- a/example_project/example_project/example_app/urls.py
+++ b/example_project/example_project/example_app/urls.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.urls import path
 from django.views.generic import TemplateView
 

--- a/example_project/example_project/example_app/views.py
+++ b/example_project/example_project/example_app/views.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import UTC
 from typing import cast
 

--- a/example_project/example_project/settings/base.py
+++ b/example_project/example_project/settings/base.py
@@ -10,6 +10,8 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.0/ref/settings/
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 
 from environs import env

--- a/example_project/example_project/settings/development.py
+++ b/example_project/example_project/settings/development.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .base import *  # noqa: F403
 from .base import env
 

--- a/example_project/example_project/settings/production.py
+++ b/example_project/example_project/settings/production.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .base import *  # noqa: F403
 from .base import env
 

--- a/example_project/example_project/settings/test.py
+++ b/example_project/example_project/settings/test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .base import *  # noqa: F403
 
 DEBUG = False

--- a/example_project/example_project/urls.py
+++ b/example_project/example_project/urls.py
@@ -15,6 +15,8 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
+from __future__ import annotations
+
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path

--- a/example_project/example_project/wsgi.py
+++ b/example_project/example_project/wsgi.py
@@ -7,6 +7,8 @@ For more information on this file, see
 https://docs.djangoproject.com/en/5.0/howto/deployment/wsgi/
 """
 
+from __future__ import annotations
+
 import os
 
 from django.core.wsgi import get_wsgi_application

--- a/example_project/manage.py
+++ b/example_project/manage.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
 
+from __future__ import annotations
+
 import os
 import sys
 

--- a/notebooks/requests_client.ipynb
+++ b/notebooks/requests_client.ipynb
@@ -17,6 +17,8 @@
     }
    ],
    "source": [
+    "from __future__ import annotations\n",
+    "\n",
     "import os\n",
     "\n",
     "import requests\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ lint.select = ["E", "F", "I", "DJ", "UP"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["adit_radis_shared", "example_project"]
+required-imports = ["from __future__ import annotations"]
 
 [tool.djlint]
 profile = "django"


### PR DESCRIPTION
Standardizes on PEP 563 deferred annotations across the codebase and enforces it with ruff.

## What
- Adds `required-imports = ["from __future__ import annotations"]` to `[tool.ruff.lint.isort]` (rule **I002**).
- Runs the autofix, which inserts `from __future__ import annotations` into every module (80 files). ruff now fails CI if any file is missing it.

## Why
- Previously the import was inconsistent (only a handful of files had it). This makes the whole codebase uniform.
- Forward references work unquoted; annotations are no longer evaluated at runtime (faster imports); and it guards against accidentally dropping a now-load-bearing future import.

## Safety
- No `pydantic`, `get_type_hints`, or `dataclasses` usage in this repo, so PEP 563 (string annotations) has no runtime-introspection impact here.
- `cli lint` (ruff, pyright, djlint) and all pre-commit hooks pass. Pure mechanical import insertion — no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code infrastructure across the codebase to standardize type annotation handling.
  * Modified import sorting configuration to enforce consistent import practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->