### PR TITLE
fix: switch from nest-asyncio to maintained nest-asyncio2 fork

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,4 @@
-import nest_asyncio
+import nest_asyncio2
 
 pytest_plugins = ["adit_radis_shared.pytest_fixtures"]
 
@@ -7,7 +7,7 @@ def pytest_configure():
     # pytest-asyncio doesn't play well with pytest-playwright as
     # pytest-playwright creates an event loop for the whole test suite and
     # pytest-asyncio can't create an additional one then.
-    # nest_asyncio works around this this by allowing to create nested loops.
+    # nest_asyncio2 works around this by allowing to create nested loops.
     # https://github.com/pytest-dev/pytest-asyncio/issues/543
     # https://github.com/microsoft/playwright-pytest/issues/167
-    nest_asyncio.apply()
+    nest_asyncio2.apply()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dev = [
     "Faker>=36.1.1",
     "ipykernel>=6.29.5",
     "ipython>=8.32.0",
+    "nest-asyncio2>=1.7.2",
     "pre-commit>=4.0.0",
     "pyright>=1.1.402",
     "pytest>=8.3.4",

--- a/uv.lock
+++ b/uv.lock
@@ -66,6 +66,7 @@ dev = [
     { name = "faker" },
     { name = "ipykernel" },
     { name = "ipython" },
+    { name = "nest-asyncio2" },
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest" },
@@ -136,6 +137,7 @@ dev = [
     { name = "faker", specifier = ">=36.1.1" },
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "ipython", specifier = ">=8.32.0" },
+    { name = "nest-asyncio2", specifier = ">=1.7.2" },
     { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pyright", specifier = ">=1.1.402" },
     { name = "pytest", specifier = ">=8.3.4" },
@@ -1419,6 +1421,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "nest-asyncio2"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/73/731debf26e27e0a0323d7bda270dc2f634b398e38f040a09da1f4351d0aa/nest_asyncio2-1.7.2.tar.gz", hash = "sha256:1921d70b92cc4612c374928d081552efb59b83d91b2b789d935c665fa01729a8", size = 14743, upload-time = "2026-02-13T00:34:04.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl", hash = "sha256:f5dfa702f3f81f6a03857e9a19e2ba578c0946a4ad417b4c50a24d7ba641fe01", size = 7843, upload-time = "2026-02-13T00:34:02.691Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

CI on the Renovate lock-file-maintenance PR ([#204](https://github.com/openradx/adit-radis-shared/pull/204)) fails at the `pyright` lint step:

```
conftest.py:1:8 - error: Import "nest_asyncio" could not be resolved (reportMissingImports)
```

`conftest.py` imported `nest_asyncio`, but **`nest-asyncio` was never a declared dependency** — it was only available transitively via `ipykernel`. The `ipykernel` 7.2.0 → 7.3.0 bump swapped its dependency from `nest-asyncio` to the maintained `nest-asyncio2` fork, so the `nest_asyncio` module is no longer installed and the import (and pyright) breaks.

## What

Switch over to `nest-asyncio2` completely (the original `nest_asyncio` is unmaintained):

- Declare `nest-asyncio2` explicitly as a dev dependency (no longer rely on a transitive chain).
- Update `conftest.py` to `import nest_asyncio2` / `nest_asyncio2.apply()`.
- Regenerate `uv.lock`.
- Fix a small pre-existing `this this` typo in the comment.

`nest-asyncio2` keeps the same `apply()` API and has **no behavior change on Python < 3.12**, so the event-loop-nesting workaround for pytest-playwright is unchanged.

## Verification

- `uv run ruff check .` → clean
- `uv run pyright` → 0 errors

## Follow-up (not in this PR)

The two upstream issues referenced in the `conftest.py` comment (`pytest-asyncio#543`, `playwright-pytest#167`) are now both closed as completed. Worth a separate experiment to check whether the `apply()` workaround can be dropped entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency to enhance test infrastructure stability.

* **Tests**
  * Improved async test-suite event-loop handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->